### PR TITLE
feat: add support for multiple collapsibles

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,10 @@ npm install --save react-collapsible-mixin
 
 ### Use
 
+* Each collapsible content element must have unique `ref` that has `collapsible` prefix
+* Each collapser (trigger) element must have `href` set referencing `'#' + ref`
+* Each collapser (trigger) element must pass `ref` of the content its responsible for toggling
+
 ```js
 var CollapsibleMixin = require('react-collapsible-mixin');
 
@@ -24,17 +28,34 @@ var MyComponent = React.createClass({
 	mixins: [CollapsibleMixin],
 
 	render: function () {
+		var c1_ref = 'collapsible-content-1';
+		var c2_ref = 'collapsible-content-2';
+
 		return (
 			<div className="row">
 				<div className="col-xs-12">
 					<a
-						className={this.getCollapserClassSet(collapserClassSet)}
+						href={'#' + c1_ref}
+						className={this.getCollapserClassSet(c1_ref)}
+						onClick={this._onToggleCollapsible}>
+						Toggle
+					</a>
+					<a
+						href={'#' + c2_ref}
+						className={this.getCollapserClassSet(c2_ref)}
 						onClick={this._onToggleCollapsible}>
 						Toggle
 					</a>
 				</div>
 				<div
-					className={this.getCollapsibleClassSet(collapsibleClassSet)}>
+					ref={c1_ref}
+					className={this.getCollapsibleClassSet(c1_ref)}>
+					<p>Here are some random content</p>
+					<p>That will toggle</p>
+				</div>
+				<div
+					ref={c2_ref}
+					className={this.getCollapsibleClassSet(c2_ref)}>
 					<p>Here are some random content</p>
 					<p>That will toggle</p>
 				</div>
@@ -51,15 +72,16 @@ following states and functions added to your component:
 
 ##### State
 
-`this.state.expanded`: indicates whether or not the component is currently
-expanded. Defaults to false unless provided via `props`.
+`this.state.expanded`: contains key values pairs that map each `ref` to
+its current expanded state. State is obtained initial after component has been
+mounted by inspecting collapsible content element for existing `in` className.
 
-##### getCollapserClassSet(defaults)
+##### getCollapserClassSet(ref, defaults)
 
 Helper function to grab class names for the collapser element. You can
 optionally pass in defaults object to set extra class names.
 
-##### getCollapsibleClassSet(defaults)
+##### getCollapsibleClassSet(ref, defaults)
 
 Helper function to grab class names for the collapsible element. You can
 optionally pass in defaults object to set extra class names.
@@ -72,3 +94,9 @@ Event handler which you can attach to collapsers.
 
 Use it with existing `LocalStorageMixin` to remember the state of the
 collapsible element.
+
+### Recent changes
+
+#### 13th Feb 2015
+
+* Add support for multiple collapsible elements

--- a/__tests__/react-collapsible-mixin-test.js
+++ b/__tests__/react-collapsible-mixin-test.js
@@ -9,64 +9,114 @@ describe('react-collapsible-mixin', function () {
 	var TestUtils        = React.addons.TestUtils;
 	var Simulate         = TestUtils.Simulate;
 	var CollapsibleMixin = require('../react-collapsible-mixin.js');
+	var extend           = require('object-assign');
 
 	var TestComponent = React.createClass({
 		mixins: [CollapsibleMixin],
 
 		render: function () {
-			var collapserClassSet   = { 'test-collapser': true };
-			var collapsibleClassSet = { 'test-collapsible': true };
+			// References for collapsible contents
+			var c1 = 'collapsible-content-1';
+			var c2 = 'collapsible-content-2';
+
+			var collapserClassSet    = { 'test-collapser': true };
+			var collapsibleClassSet  = { 'test-collapsible': true };
+			var collapsibleClassSet2 = extend({ 'in': true }, collapsibleClassSet);
 
 			return (
-				<div className="row">
-					<div className="col-xs-12">
-						<a
-							className={this.getCollapserClassSet(collapserClassSet)}
-							onClick={this._onToggleCollapsible}>
-							Toggle
-						</a>
+				<div className="container">
+					<div className="row">
+						<div className="col-xs-12">
+							<a
+								href={'#' + c1}
+								className={this.getCollapserClassSet(c1, collapserClassSet)}
+								onClick={this._onToggleCollapsible}>
+								Toggle
+							</a>
+						</div>
+						<div
+							id={c1}
+							ref={c1}
+							className={this.getCollapsibleClassSet(c1, collapsibleClassSet)}>
+							<p>Here are some random content</p>
+							<p>That will toggle</p>
+						</div>
 					</div>
-					<div
-						className={this.getCollapsibleClassSet(collapsibleClassSet)}>
-						<p>Here are some random content</p>
-						<p>That will toggle</p>
+					<div className="row">
+						<div className="col-xs-12">
+							<a
+								href={'#' + c2}
+								className={this.getCollapserClassSet(c2, collapserClassSet)}
+								onClick={this._onToggleCollapsible}>
+								<span
+									className="nested">
+									Toggle
+								</span>
+							</a>
+						</div>
+						<div
+							id={c2}
+							ref={c2}
+							className={this.getCollapsibleClassSet(c2, collapsibleClassSet2)}>
+							<p>Here are some random content</p>
+							<p>That will toggle</p>
+						</div>
 					</div>
 				</div>
 			);
 		}
 	});
 
-	var component, content, collapser;
+	var component, content1, content2, collapser1, collapser2, collapser2nested;
 	beforeEach(function () {
 		component = TestUtils.renderIntoDocument(
 			<TestComponent />
 		);
 
-		content = TestUtils.findRenderedDOMComponentWithClass(component, 'test-collapsible');
-		collapser = TestUtils.findRenderedDOMComponentWithClass(component, 'test-collapser');
+		var collapsers = TestUtils.scryRenderedDOMComponentsWithClass(component, 'test-collapser');
+		var contents   = TestUtils.scryRenderedDOMComponentsWithClass(component, 'test-collapsible');
+
+		collapser1     = collapsers[0];
+		collapser2     = collapsers[1];
+		content1       = contents[0];
+		content2       = contents[1];
+
+		collapser2nested = TestUtils.findRenderedDOMComponentWithClass(component, 'nested');
 	});
 
 	describe('default state', function () {
-		it('should have state set to false default', function () {
-			expect(component.state.expanded).toBe(false);
-		});
-
 		it('should have collapsed class on the collapser', function () {
-			expect(toArray(collapser.props.className)).toContain('collapsed');
+			expect(toArray(collapser1.props.className)).toContain('collapsed');
+			expect(toArray(collapser2.props.className)).not.toContain('collapsed');
 		});
 
 		it('should have collapse class on the content', function () {
-			expect(toArray(content.props.className)).toContain('collapse');
-			expect(toArray(content.props.className)).not.toContain('in');
+			expect(toArray(content1.props.className)).toContain('collapse');
+			expect(toArray(content1.props.className)).not.toContain('in');
+
+			expect(toArray(content2.props.className)).toContain('collapse');
+			expect(toArray(content2.props.className)).toContain('in');
 		});
 	});
 
 	describe('toggling via collapser', function () {
 		it('should show on click of the collapser', function () {
-			Simulate.click(collapser);
+			Simulate.click(collapser1);
 
-			expect(toArray(collapser.props.className)).not.toContain('collapsed');
-			expect(toArray(content.props.className)).toContain('in');
+			expect(toArray(collapser1.props.className)).not.toContain('collapsed');
+			expect(toArray(content1.props.className)).toContain('in');
+
+			Simulate.click(collapser2);
+
+			expect(toArray(collapser2.props.className)).toContain('collapsed');
+			expect(toArray(content2.props.className)).not.toContain('in');
+		});
+
+		it('should work when nested element raised an event', function () {
+			Simulate.click(collapser2nested);
+
+			expect(toArray(collapser2.props.className)).toContain('collapsed');
+			expect(toArray(content2.props.className)).not.toContain('in');
 		});
 	});
 });

--- a/package.json
+++ b/package.json
@@ -31,12 +31,14 @@
   },
   "devDependencies": {
     "jest-cli": "^0.2.2",
+    "object-assign": "^2.0.0",
     "react-tools": "^0.12.2"
   },
   "jest": {
     "scriptPreprocessor": "<rootDir>/preprocessor.js",
     "unmockedModulePathPatterns": [
-      "/node_modules/react"
+      "/node_modules/react",
+	  "/node_modules/object-assign"
     ]
   }
 }

--- a/react-collapsible-mixin.js
+++ b/react-collapsible-mixin.js
@@ -2,51 +2,68 @@ var React = require('react/addons');
 var Types = React.PropTypes;
 var cx    = React.addons.classSet;
 
+function isCollapsibleRef(ref) {
+	return ref.search(/^collapsible/) === 0;
+}
+
+function hasClass(className, _class) {
+	return (className || '').split(' ').indexOf(_class) >= 0;
+}
+
 var CollapsibleMixin = {
 	propTypes: {
-		expanded: Types.bool
-	},
-
-	getDefaultProps: function () {
-		return {
-			expanded: false
-		};
+		expanded: Types.objectOf(Types.bool)
 	},
 
 	getInitialState: function () {
 		return {
-			expanded: this.props.expanded
+			expanded: this.props.expanded || {}
 		};
 	},
 
-	componentWillReceiveProps: function (delta) {
-		if ('expanded' in delta) {
-			this.setState({
-				expanded: delta.expanded
-			});
-		}
+	// When component mounts, inspect all the collapsible elements and
+	// determine their current expanded states by looking for class name `in`.
+	componentDidMount: function () {
+		var collapsibles = Object.keys(this.refs).filter(isCollapsibleRef);
+		var expanded = collapsibles.reduce(function (result, collapsible) {
+			result[collapsible] = hasClass(this.refs[collapsible].props.className, 'in');
+			return result;
+		}.bind(this), {});
+		this.setState({ expanded: expanded });
 	},
 
-	getCollapserClassSet: function (defaults) {
+	getCollapserClassSet: function (ref, defaults) {
 		defaults = defaults || {};
 		defaults.collapser = true;
-		defaults.collapsed = !this.state.expanded;
+		defaults[ref] = true;
+		if (ref in this.state.expanded) {
+			defaults.collapsed = !this.state.expanded[ref];
+		}
 		return cx(defaults);
 	},
 
-	getCollapsibleClassSet: function (defaults) {
+	getCollapsibleClassSet: function (ref, defaults) {
 		defaults = defaults || {};
 		defaults.collapse = true;
-		defaults['in'] = this.state.expanded;
+		defaults[ref] = true;
+		if (ref in this.state.expanded) {
+			defaults['in'] = this.state.expanded[ref];
+		}
 		return cx(defaults);
 	},
 
 	_onToggleCollapsible: function (event) {
-		event.preventDefault();
+		var target   = event.currentTarget.getAttribute('href');
+		var expanded = this.state.expanded;
 
-		this.setState({
-			expanded: !this.state.expanded
-		});
+		if (target) {
+			event.preventDefault();
+			target = target.replace(/^#/, '');
+			expanded[target] = !this.state.expanded[target];
+			this.setState({
+				expanded: expanded
+			});
+		}
 	}
 };
 


### PR DESCRIPTION
Adds support for multiple collapsibles by keeping `expanded` state tied to each collapsible element's `ref` key. The API becomes a little more verbose, so if anyone have any suggestions on how to tackle this best, let's discuss it here.

@dwendo to review.
